### PR TITLE
Better Corpse Description

### DIFF
--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -614,6 +614,25 @@ void Creature::onCreatureMove(Creature* creature, const Tile* newTile, const Pos
 	}
 }
 
+std::vector<Creature*> Creature::getKillers()
+{
+	std::vector<Creature*> killers;
+	killers.reserve(damageMap.size());
+	const int64_t timeNow = OTSYS_TIME();
+	const uint32_t inFightTicks = g_config.getNumber(ConfigManager::PZ_LOCKED);
+	for (const auto& it : damageMap) {
+		if (Creature* attacker = g_game.getCreatureByID(it.first)) {
+			CountBlock_t cb = it.second;
+			if (timeNow - cb.ticks <= inFightTicks) {
+				if (attacker != this) {
+					killers.push_back(attacker);
+				}
+			}
+		}
+	}
+	return killers;
+}
+
 void Creature::onDeath()
 {
 	bool lastHitUnjustified = false;

--- a/src/creature.h
+++ b/src/creature.h
@@ -343,6 +343,7 @@ class Creature : virtual public Thing
 			return false;
 		}
 
+		std::vector<Creature*> getKillers();
 		void onDeath();
 		virtual uint64_t getGainedExperience(Creature* attacker) const;
 		void addDamagePoints(Creature* attacker, int32_t damagePoints);

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -2097,11 +2097,30 @@ Item* Player::getCorpse(Creature* lastHitCreature, Creature* mostDamageCreature)
 {
 	Item* corpse = Creature::getCorpse(lastHitCreature, mostDamageCreature);
 	if (corpse && corpse->getContainer()) {
+		std::map<std::string, uint16_t> names;
+		for (const auto& killer : getKillers()) {
+			names[killer->getName()]++;
+		}
+
 		std::ostringstream ss;
+		ss << "You recognize " << getNameDescription() << ". " << (getSex() == PLAYERSEX_FEMALE ? "She" : "He") << " was killed by ";
+		size_t countNames = names.size();
 		if (lastHitCreature) {
-			ss << "You recognize " << getNameDescription() << ". " << (getSex() == PLAYERSEX_FEMALE ? "She" : "He") << " was killed by " << lastHitCreature->getNameDescription() << '.';
+			if (countNames == 1) {
+				ss << lastHitCreature->getNameDescription() << '.';
+			} else if (mostDamageCreature && names[mostDamageCreature->getName()] >= 1) {
+				ss << mostDamageCreature->getNameDescription();
+				if (lastHitCreature != mostDamageCreature && names[lastHitCreature->getName()] == 1) {
+					ss << " and " << lastHitCreature->getNameDescription();
+					if (countNames > 2) {
+						ss << " and others.";
+					}
+				} else {
+					ss << " and others.";
+				}
+			}
 		} else {
-			ss << "You recognize " << getNameDescription() << '.';
+			ss << "something evil.";
 		}
 
 		corpse->setSpecialDescription(ss.str());


### PR DESCRIPTION
> Proposed by @EPuncker

These changes were suggested in PR Unknow now so with these changes most of what was mentioned is achieved, then the things that were added were:

- [x] add most damage name to corpse (killed by %most damage% and %lasthit%)
- [x] add (Killed by something evil.) if the killer is script/item/magic field
- [x] add (and others) if there is more than 2 "damagers"
- [x] if the "damagers" are an named "A" and 5 named "B", it will be (Killed by A and others) and not (Killed by A and B and others)
- [x] in case of a summon, nothing changes, still "most damage and last hit [and others]"

I was not quite sure how to know when a player dies from evil causes or is affected by them, so in these changes, it is the only thing that is needed, I do not see it very necessary, but if someone can help, please!

Like I said, if you can help, it would be perfect, I'll be doing more tests, to see if I can find problems or some way to improve this.